### PR TITLE
Reference issues

### DIFF
--- a/Examples/Example.Forms/Example.Forms.iOS/Example.Forms.iOS.csproj
+++ b/Examples/Example.Forms/Example.Forms.iOS/Example.Forms.iOS.csproj
@@ -146,8 +146,16 @@
       <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
     <ProjectReference Include="..\Example.Forms\Example.Forms.csproj">
-      <Project>{75bf924b-e18f-4b37-8c42-36525eec73bb}</Project>
+      <Project>{BA40E6BD-F568-4301-A402-3846F176D49E}</Project>
       <Name>Example.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Lottie.Forms\Lottie.Forms.csproj">
+      <Project>{F03D2DD6-BBDA-45B9-982E-4DCA43FCB8E1}</Project>
+      <Name>Lottie.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Lottie.iOS\Lottie.iOS.csproj">
+      <Project>{8F0CC2B2-88E2-459B-AC92-F3A74071707E}</Project>
+      <Name>Lottie.iOS</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Lottie.Forms.Droid/AnimationViewRenderer.cs
+++ b/Lottie.Forms.Droid/AnimationViewRenderer.cs
@@ -26,14 +26,8 @@ namespace Lottie.Forms.Droid
            #pragma warning restore 0219
         }
 
-        public AnimationViewRenderer()
-        {
-            var i = 2;
-        }
-
         protected override void OnElementChanged(ElementChangedEventArgs<AnimationView> e)
         {
-            System.Diagnostics.Debug.WriteLine("THINGS ARE HAPPENIGN!!!");
             base.OnElementChanged(e);
 
             if (Control == null)
@@ -87,7 +81,6 @@ namespace Lottie.Forms.Droid
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            System.Diagnostics.Debug.WriteLine("FJRWIJFWIEJFEWIJFWEI");
             if (e.PropertyName == AnimationView.AnimationProperty.PropertyName)
             {
                 _animationView.SetAnimation(Element.Animation);
@@ -100,7 +93,8 @@ namespace Lottie.Forms.Droid
 
             if (e.PropertyName == AnimationView.ProgressProperty.PropertyName)
             {
-                _animationView.Progress = Element.Progress;
+				_animationView.PauseAnimation();
+				_animationView.Progress = Element.Progress;
             }
 
             if (e.PropertyName == AnimationView.LoopProperty.PropertyName)

--- a/Lottie.Forms.Droid/Lottie.Forms.Droid.csproj
+++ b/Lottie.Forms.Droid/Lottie.Forms.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -39,10 +39,6 @@
   <ItemGroup>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Xamarin.Forms.2.3.3.180\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Lottie, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Com.Airbnb.Android.Lottie.1.0.0.2\lib\MonoAndroid41\Lottie.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Android" />

--- a/Lottie.Forms.Droid/packages.config
+++ b/Lottie.Forms.Droid/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Com.Airbnb.Android.Lottie" version="1.0.0.2" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid70" />

--- a/Lottie.Forms.iOS/Lottie.Forms.iOS.csproj
+++ b/Lottie.Forms.iOS/Lottie.Forms.iOS.csproj
@@ -89,10 +89,6 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Lottie.iOS, Version=1.0.6244.36778, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Com.Airbnb.iOS.Lottie.1.0.0.2\lib\xamarinios\Lottie.iOS.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
@@ -131,6 +127,10 @@
     <ProjectReference Include="..\Lottie.Forms\Lottie.Forms.csproj">
       <Project>{F03D2DD6-BBDA-45B9-982E-4DCA43FCB8E1}</Project>
       <Name>Lottie.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Lottie.iOS\Lottie.iOS.csproj">
+      <Project>{8F0CC2B2-88E2-459B-AC92-F3A74071707E}</Project>
+      <Name>Lottie.iOS</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Lottie.Forms.iOS/packages.config
+++ b/Lottie.Forms.iOS/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Com.Airbnb.iOS.Lottie" version="1.0.0.2" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.3.3.180" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
This PR fixes removes a wrong reference to the Lottie nuget package for Forms.iOS and Forms.Droid project. Fixed by referencing the projects instead.
It also removes some debug text that somehow slipped through in the last PR.