### PR TITLE
Add missing armv7s architecture

### DIFF
--- a/Examples/Example.iOS/Example.iOS.csproj
+++ b/Examples/Example.iOS/Example.iOS.csproj
@@ -71,10 +71,9 @@
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>true</MtouchFastDev>
-    <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARMv7s, ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>

--- a/nuspec/Com.Airbnb.iOS.Lottie.nuspec
+++ b/nuspec/Com.Airbnb.iOS.Lottie.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Com.Airbnb.iOS.Lottie</id>
-        <version>2.5.0.0</version>
+        <version>2.5.0.1</version>
         <title>Lottie for Xamarin.iOS, macOS and tvOS</title>
         <authors>Martijn van Dijk</authors>
         <owners>Martijn van Dijk</owners>


### PR DESCRIPTION
The current fat native library doesn't has the armv7s architecture.
Without it, if your project support only `ARMv7s` or `ARMv7S+ARM64` architectures, you can see an error message like this when trying to run on some devices:

```
Error: Invalid bitcode signature
Clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: Native linking failed. Please review the build log.
```