### PR TITLE
Added PlaySegment method to Xamarin.Forms

### DIFF
--- a/Examples/Example.Forms/Example.Forms/MainPage.xaml
+++ b/Examples/Example.Forms/Example.Forms/MainPage.xaml
@@ -22,6 +22,11 @@
             AbsoluteLayout.LayoutBounds="0, 0, AutoSize, AutoSize"
             Text="Play"
             Margin="10" />
+        <Button x:Name="playSegmentsButton"
+            AbsoluteLayout.LayoutFlags="PositionProportional"
+            AbsoluteLayout.LayoutBounds="0.5, 0, AutoSize, AutoSize"
+            Text="Play Segment"
+            Margin="10" />
         <Button x:Name="pauseButton"
             AbsoluteLayout.LayoutFlags="PositionProportional"
             AbsoluteLayout.LayoutBounds="1, 0, AutoSize, AutoSize"

--- a/Examples/Example.Forms/Example.Forms/MainPage.xaml
+++ b/Examples/Example.Forms/Example.Forms/MainPage.xaml
@@ -4,37 +4,57 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
     xmlns:forms="clr-namespace:Lottie.Forms;assembly=Lottie.Forms" 
     x:Class="Example.Forms.MainPage">
-    <AbsoluteLayout>
-        <forms:AnimationView x:Name="animationView" 
-            AbsoluteLayout.LayoutFlags="All"
-            AbsoluteLayout.LayoutBounds="0, 0, 1, 1"
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackLayout
+            Grid.Row="0"
+            Orientation="Horizontal"
+            HorizontalOptions="FillAndExpand"
+            Margin="5, 0">
+            
+            <Button 
+                x:Name="playButton"
+                HorizontalOptions="FillAndExpand"
+                Text="Play" />
+
+            <Button 
+                x:Name="playSegmentsButton"
+                HorizontalOptions="FillAndExpand"
+                Text="Segment" />
+
+            <Button 
+                x:Name="playFramesButton"
+                HorizontalOptions="FillAndExpand"
+                Text="Frames" />
+            
+            <Button 
+                x:Name="pauseButton"
+                HorizontalOptions="FillAndExpand"
+                Text="Pause" />
+        </StackLayout>
+
+        <forms:AnimationView 
+            x:Name="animationView" 
+            Grid.Row="1"
             Animation="LottieLogo1.json" 
             Loop="false" 
-            AutoPlay="true"
+            AutoPlay="false"
             OnFinish="Handle_OnFinish"
             PlaybackStartedCommand="{Binding PlayingCommand}"
             PlaybackFinishedCommand="{Binding FinishedCommand}" 
             ClickedCommand="{Binding ClickedCommand}"
             VerticalOptions="FillAndExpand" 
             HorizontalOptions="FillAndExpand" />
-        <Button x:Name="playButton"
-            AbsoluteLayout.LayoutFlags="PositionProportional"
-            AbsoluteLayout.LayoutBounds="0, 0, AutoSize, AutoSize"
-            Text="Play"
-            Margin="10" />
-        <Button x:Name="playSegmentsButton"
-            AbsoluteLayout.LayoutFlags="PositionProportional"
-            AbsoluteLayout.LayoutBounds="0.5, 0, AutoSize, AutoSize"
-            Text="Play Segment"
-            Margin="10" />
-        <Button x:Name="pauseButton"
-            AbsoluteLayout.LayoutFlags="PositionProportional"
-            AbsoluteLayout.LayoutBounds="1, 0, AutoSize, AutoSize"
-            Text="Pause"
-            Margin="10" />
+
         <Slider 
-            AbsoluteLayout.LayoutFlags="PositionProportional, WidthProportional"
-            AbsoluteLayout.LayoutBounds="0, 1, 1, AutoSize"
+            Grid.Row="2"
+            Margin="5, 0"
             ValueChanged="Slider_OnValueChanged" />
-    </AbsoluteLayout>
+    </Grid>
 </ContentPage>

--- a/Examples/Example.Forms/Example.Forms/MainPage.xaml.cs
+++ b/Examples/Example.Forms/Example.Forms/MainPage.xaml.cs
@@ -27,6 +27,7 @@ namespace Example.Forms
             InitializeComponent();
 
             playButton.Clicked += (sender, e) => animationView.Play();
+            playSegmentsButton.Clicked += (sender, e) => animationView.PlaySegment(0.65f, 0.0f);
             pauseButton.Clicked += (sender, e) => animationView.Pause();
 
             BindingContext = this;

--- a/Examples/Example.Forms/Example.Forms/MainPage.xaml.cs
+++ b/Examples/Example.Forms/Example.Forms/MainPage.xaml.cs
@@ -1,36 +1,36 @@
 ﻿using System.Windows.Input;
 using Xamarin.Forms;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Example.Forms
 {
     public partial class MainPage : ContentPage
     {
-        private readonly ICommand playingCommand;
-        private readonly ICommand finishedCommand;
-        private readonly ICommand clickedCommand;
-
-        public ICommand PlayingCommand => playingCommand;
-        public ICommand FinishedCommand => finishedCommand;
-        public ICommand ClickedCommand => clickedCommand;
+        public ICommand PlayingCommand { get; private set; }
+        public ICommand FinishedCommand { get; private set; }
+        public ICommand ClickedCommand { get; private set; }
 
         public MainPage()
         {
-            playingCommand = new Command(_ =>
+            PlayingCommand = new Command(_ =>
                 DisplayAlert($"{nameof(animationView.PlaybackStartedCommand)} executed!"));
 
-            finishedCommand = new Command(_ =>
+            FinishedCommand = new Command(_ =>
                 DisplayAlert($"{nameof(animationView.PlaybackFinishedCommand)} executed!"));
 
-            clickedCommand = new Command(_ =>
+            ClickedCommand = new Command(_ =>
                  DisplayAlert($"{nameof(animationView.ClickedCommand)} executed!"));
             
             InitializeComponent();
 
             playButton.Clicked += (sender, e) => animationView.Play();
-            playSegmentsButton.Clicked += (sender, e) => animationView.PlaySegment(0.65f, 0.0f);
+            playSegmentsButton.Clicked += (sender, e) => animationView.PlayProgressSegment(0.65f, 0.0f);
+            playFramesButton.Clicked += (sender, e) => animationView.PlayFrameSegment(50, 1);
             pauseButton.Clicked += (sender, e) => animationView.Pause();
 
             BindingContext = this;
+
+            On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(true);
         }
 
         private void Slider_OnValueChanged(object sender, ValueChangedEventArgs e)

--- a/Lottie.Forms.iOS/Renderers/AnimationViewRenderer.cs
+++ b/Lottie.Forms.iOS/Renderers/AnimationViewRenderer.cs
@@ -36,12 +36,14 @@ namespace Lottie.Forms.iOS.Renderers
             {
                 e.OldElement.OnPlay -= OnPlay;
                 e.OldElement.OnPause -= OnPause;
+                e.OldElement.OnPlaySegment -= OnPlaySegment;
             }
 
             if (e.NewElement == null) return;
 
             e.NewElement.OnPlay += OnPlay;
             e.NewElement.OnPause += OnPause;
+            e.NewElement.OnPlaySegment += OnPlaySegment;
 
             if (!string.IsNullOrEmpty(e.NewElement.Animation))
             {
@@ -52,6 +54,12 @@ namespace Lottie.Forms.iOS.Renderers
         private void OnPlay(object sender, EventArgs e)
         {
             _animationView?.PlayWithCompletion(PlaybackFinishedIfActually);
+            Element.IsPlaying = true;
+        }
+
+        private void OnPlaySegment(object sender, SegmentEventArgs e)
+        {
+            _animationView?.PlayFromProgress(e.From, e.To, PlaybackFinishedIfActually);
             Element.IsPlaying = true;
         }
 

--- a/Lottie.Forms.iOS/Renderers/AnimationViewRenderer.cs
+++ b/Lottie.Forms.iOS/Renderers/AnimationViewRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using Airbnb.Lottie;
 using Foundation;
 using Lottie.Forms;
+using Lottie.Forms.EventArguments;
 using Lottie.Forms.iOS.Renderers;
 using UIKit;
 using Xamarin.Forms;
@@ -36,14 +37,16 @@ namespace Lottie.Forms.iOS.Renderers
             {
                 e.OldElement.OnPlay -= OnPlay;
                 e.OldElement.OnPause -= OnPause;
-                e.OldElement.OnPlaySegment -= OnPlaySegment;
+                e.OldElement.OnPlayProgressSegment -= OnPlayProgressSegment;
+                e.OldElement.OnPlayFrameSegment -= OnPlayFrameSegment;
             }
 
             if (e.NewElement == null) return;
 
             e.NewElement.OnPlay += OnPlay;
             e.NewElement.OnPause += OnPause;
-            e.NewElement.OnPlaySegment += OnPlaySegment;
+            e.NewElement.OnPlayProgressSegment += OnPlayProgressSegment;
+            e.NewElement.OnPlayFrameSegment += OnPlayFrameSegment;
 
             if (!string.IsNullOrEmpty(e.NewElement.Animation))
             {
@@ -57,9 +60,15 @@ namespace Lottie.Forms.iOS.Renderers
             Element.IsPlaying = true;
         }
 
-        private void OnPlaySegment(object sender, SegmentEventArgs e)
+        private void OnPlayProgressSegment(object sender, ProgressSegmentEventArgs e)
         {
             _animationView?.PlayFromProgress(e.From, e.To, PlaybackFinishedIfActually);
+            Element.IsPlaying = true;
+        }
+
+        private void OnPlayFrameSegment(object sender, FrameSegmentEventArgs e)
+        {
+            _animationView?.PlayFromFrame(e.From, e.To, PlaybackFinishedIfActually);
             Element.IsPlaying = true;
         }
 

--- a/Lottie.Forms/AnimationView.cs
+++ b/Lottie.Forms/AnimationView.cs
@@ -116,6 +116,21 @@ namespace Lottie.Forms
             ExecuteCommandIfPossible(PlaybackStartedCommand);
         }
 
+        public event EventHandler<SegmentEventArgs> OnPlaySegment;
+
+        public void PlaySegment(float from, float to)
+        {
+            if (from < 0f || from > 1f)
+                throw new ArgumentException($"Parameter {nameof(from)} should have a valid value.", nameof(from));
+
+            if (to < 0f || to > 1f)
+                throw new ArgumentException($"Parameter {nameof(to)} should have a valid value.", nameof(to));
+            
+            OnPlaySegment?.Invoke(this, new SegmentEventArgs(from, to));
+
+            ExecuteCommandIfPossible(PlaybackStartedCommand);
+        }
+
         public event EventHandler OnPause;
 
         public void Pause()

--- a/Lottie.Forms/AnimationView.cs
+++ b/Lottie.Forms/AnimationView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
+using Lottie.Forms.EventArguments;
 using Xamarin.Forms;
 
 namespace Lottie.Forms
@@ -116,9 +117,9 @@ namespace Lottie.Forms
             ExecuteCommandIfPossible(PlaybackStartedCommand);
         }
 
-        public event EventHandler<SegmentEventArgs> OnPlaySegment;
+        public event EventHandler<ProgressSegmentEventArgs> OnPlayProgressSegment;
 
-        public void PlaySegment(float from, float to)
+        public void PlayProgressSegment(float from, float to)
         {
             if (from < 0f || from > 1f)
                 throw new ArgumentException($"Parameter {nameof(from)} should have a valid value.", nameof(from));
@@ -126,7 +127,22 @@ namespace Lottie.Forms
             if (to < 0f || to > 1f)
                 throw new ArgumentException($"Parameter {nameof(to)} should have a valid value.", nameof(to));
             
-            OnPlaySegment?.Invoke(this, new SegmentEventArgs(from, to));
+            OnPlayProgressSegment?.Invoke(this, new ProgressSegmentEventArgs(from, to));
+
+            ExecuteCommandIfPossible(PlaybackStartedCommand);
+        }
+
+        public event EventHandler<FrameSegmentEventArgs> OnPlayFrameSegment;
+
+        public void PlayFrameSegment(int from, int to)
+        {
+            if (from < 0)
+                throw new ArgumentException($"Parameter {nameof(from)} should have a valid value.", nameof(from));
+
+            if (to < 0)
+                throw new ArgumentException($"Parameter {nameof(to)} should have a valid value.", nameof(to));
+
+            OnPlayFrameSegment?.Invoke(this, new FrameSegmentEventArgs(from, to));
 
             ExecuteCommandIfPossible(PlaybackStartedCommand);
         }

--- a/Lottie.Forms/EventArguments/FrameSegmentEventArgs.cs
+++ b/Lottie.Forms/EventArguments/FrameSegmentEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Lottie.Forms.EventArguments
+{
+    public class FrameSegmentEventArgs : EventArgs
+    {
+        public int From { get; set; }
+        public int To { get; set; }
+
+        public FrameSegmentEventArgs()
+            :base()
+        {
+        }
+
+        public FrameSegmentEventArgs(int from, int to)
+        {
+            From = from;
+            To = to;
+        }
+    }
+}

--- a/Lottie.Forms/EventArguments/ProgressSegmentEventArgs.cs
+++ b/Lottie.Forms/EventArguments/ProgressSegmentEventArgs.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 
-namespace Lottie.Forms
+namespace Lottie.Forms.EventArguments
 {
-    public class SegmentEventArgs : EventArgs
+    public class ProgressSegmentEventArgs : EventArgs
     {
         public float From { get; set; }
         public float To { get; set; }
 
-        public SegmentEventArgs()
+        public ProgressSegmentEventArgs()
             :base()
         {
         }
 
-        public SegmentEventArgs(float from, float to)
+        public ProgressSegmentEventArgs(float from, float to)
         {
             From = from;
             To = to;

--- a/Lottie.Forms/Lottie.Forms.csproj
+++ b/Lottie.Forms/Lottie.Forms.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AnimationView.cs" />
+    <Compile Include="SegmentEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">

--- a/Lottie.Forms/Lottie.Forms.csproj
+++ b/Lottie.Forms/Lottie.Forms.csproj
@@ -35,7 +35,8 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AnimationView.cs" />
-    <Compile Include="SegmentEventArgs.cs" />
+    <Compile Include="EventArguments\FrameSegmentEventArgs.cs" />
+    <Compile Include="EventArguments\ProgressSegmentEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
@@ -50,6 +51,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="EventArguments\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Forms.2.5.0.280555\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.280555\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" />

--- a/Lottie.Forms/SegmentEventArgs.cs
+++ b/Lottie.Forms/SegmentEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Lottie.Forms
+{
+    public class SegmentEventArgs : EventArgs
+    {
+        public float From { get; set; }
+        public float To { get; set; }
+
+        public SegmentEventArgs()
+            :base()
+        {
+        }
+
+        public SegmentEventArgs(float from, float to)
+        {
+            From = from;
+            To = to;
+        }
+    }
+}


### PR DESCRIPTION
I added `PlaySegment` method so we may now play a specific part of an animation (based on its progress).
For example, `PlaySegment(0.15f, 0.55f)`. And it supports reversing like `PlaySegment(1.0f, 0.6f)`.

At the moment there is no way to use loop along with play segment.

It works on all three platforms. While iOS implementation took the least amount of time, an implementation for the other two platforms were a challenge 😁 (both does not support inverted values in SetMinAndMaxProgress method).

In addition, I fixed an issue with Loop in UWP.

Waiting for a feedback.