### PR TITLE
Forms Play method restarts animation from the beginning on Android

### DIFF
--- a/Lottie.Forms.Droid/AnimationViewRenderer.cs
+++ b/Lottie.Forms.Droid/AnimationViewRenderer.cs
@@ -71,7 +71,14 @@ namespace Lottie.Forms.Droid
             if (_animationView != null
                 && _animationView.Handle != IntPtr.Zero)
             {
-                _animationView.PlayAnimation();
+                if (_animationView.Progress > 0f)
+                {
+                    _animationView.ResumeAnimation();
+                }
+                else
+                {
+                    _animationView.PlayAnimation();
+                }
                 Element.IsPlaying = true;
             }
         }


### PR DESCRIPTION
This behavior occurs due differences between Android and iOS native libraries.
The Android version has a specific method to resume animation.

To match the iOS behavior, I'm changing the `Play` method to call
`ResumeAnimation` if animation progress is greater than zero.

Fixes #144 