### PR TITLE
Forms Play method restarts animation from the beginning on UWP

### DIFF
--- a/Lottie.Forms.UWP/Renderers/AnimationViewRenderer.cs
+++ b/Lottie.Forms.UWP/Renderers/AnimationViewRenderer.cs
@@ -89,8 +89,15 @@ namespace Lottie.Forms.UWP.Renderers
         {
             if (_animationView != null)
             {
-                ResetReverse();
-                _animationView.PlayAnimation();
+                if (_animationView.Progress > 0f)
+                {
+                    _animationView.ResumeAnimation();
+                }
+                else
+                {
+                    ResetReverse();
+                    _animationView.PlayAnimation();
+                }
                 Element.IsPlaying = true;
             }
         }


### PR DESCRIPTION
Lottie.UWP has a specific method to resume animation, so we need to call `ResumeAnimation` if animation progress is greater than zero.

I can't test this fix, but looking inside Lottie.UWP source code this will fix the problem.

Fixes  #153