### PR TITLE
Can now set ImageAssetsFolder on Android and UWP in XF

### DIFF
--- a/Lottie.Forms/AnimationView.cs
+++ b/Lottie.Forms/AnimationView.cs
@@ -38,6 +38,9 @@ namespace Lottie.Forms
         public static readonly BindableProperty ClickedCommandProperty = BindableProperty.Create(nameof(ClickedCommand), 
             typeof(ICommand), typeof(AnimationView));
 
+        public static readonly BindableProperty ImageAssetsFolderProperty = BindableProperty.Create(nameof(ImageAssetsFolder),
+            typeof(string), typeof(AnimationView), default(string));
+
         public float Progress
         {
             get { return (float) GetValue(ProgressProperty); }
@@ -106,6 +109,12 @@ namespace Lottie.Forms
             get { return (ICommand)GetValue(ClickedCommandProperty); }
 
             set { SetValue(ClickedCommandProperty, value); }
+        }
+
+        public string ImageAssetsFolder
+        {
+            get { return (string)GetValue(ImageAssetsFolderProperty); }
+            set { SetValue(ImageAssetsFolderProperty, value); }
         }
 
         public event EventHandler OnPlay;

--- a/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
@@ -63,7 +63,7 @@ namespace Lottie.Forms.Droid
 
                 _animationView.Speed = e.NewElement.Speed;
                 _animationView.Loop(e.NewElement.Loop);
-                _animationView.ImageAssetsFolder = Control.ImageAssetsFolder;
+                _animationView.ImageAssetsFolder = e.NewElement.ImageAssetsFolder;
 
                 _animationView.SetOnClickListener(new ClickListener(e.NewElement));
 

--- a/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
@@ -63,6 +63,7 @@ namespace Lottie.Forms.Droid
 
                 _animationView.Speed = e.NewElement.Speed;
                 _animationView.Loop(e.NewElement.Loop);
+                _animationView.ImageAssetsFolder = Control.ImageAssetsFolder;
 
                 _animationView.SetOnClickListener(new ClickListener(e.NewElement));
 
@@ -176,6 +177,9 @@ namespace Lottie.Forms.Droid
 
             if (e.PropertyName == AnimationView.LoopProperty.PropertyName) 
                 _animationView?.Loop(Element.Loop);
+
+            if (e.PropertyName == AnimationView.ImageAssetsFolderProperty.PropertyName)
+                _animationView.ImageAssetsFolder = Element.ImageAssetsFolder;
 
             base.OnElementPropertyChanged(sender, e);
         }

--- a/Lottie.Forms/Platforms/Uap/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Uap/AnimationViewRenderer.cs
@@ -62,6 +62,7 @@ namespace Lottie.Forms.UWP.Renderers
 
                 _animationView.RepeatCount = e.NewElement.Loop ? -1 : 0;
                 _animationView.Speed = e.NewElement.Speed;
+                _animationView.ImageAssetsFolder = e.NewElement.ImageAssetsFolder;
                 _animationView.Tapped += AnimationViewTapped;
                 _animationView.AnimatorUpdate += PlaybackFinishedIfProgressReachesOne;
 
@@ -185,6 +186,11 @@ namespace Lottie.Forms.UWP.Renderers
             if (e.PropertyName == AnimationView.SpeedProperty.PropertyName)
             {
                 _animationView.Speed = Element.Speed;
+            }
+
+            if (e.PropertyName == AnimationView.ImageAssetsFolderProperty.PropertyName)
+            {
+                _animationView.ImageAssetsFolder = Element.ImageAssetsFolder;
             }
 
             base.OnElementPropertyChanged(sender, e);


### PR DESCRIPTION
### :sparkles: Feature

### :arrow_heading_down: Can't set ImageAssetsFolder on Android and UWP

### :new: Can now set ImageAssetsFolder

### :boom: No

### :memo: #95 #48 

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Rebased onto current develop
