### PR TITLE
[Xamarin.iOS] Fix Error BlockLiteral dynamic registerar on Iphone XS

### DIFF
--- a/Lottie.iOS/LOTAnimationView.cs
+++ b/Lottie.iOS/LOTAnimationView.cs
@@ -9,13 +9,15 @@ namespace Airbnb.Lottie
         /// <summary>
         /// Asynchronously play the animation.
         /// </summary>
-        public Task<bool> PlayAsync()
+        public async Task<bool> PlayAsync()
         {
             var tcs = new TaskCompletionSource<bool>();
+            
+            this.CompletionBlock = animationFinished => tcs.SetResult(true);
+            
+            this.Play();
 
-            this.PlayWithCompletion((bool animationFinished) => tcs.SetResult(animationFinished));
-
-            return tcs.Task;
+            await tcs.Task;
         }
 
 		/// <summary>

--- a/Lottie.iOS/LOTAnimationView.cs
+++ b/Lottie.iOS/LOTAnimationView.cs
@@ -17,7 +17,7 @@ namespace Airbnb.Lottie
             
             this.Play();
 
-            await tcs.Task;
+            return await tcs.Task;
         }
 
 		/// <summary>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR fix the asynchronous method with PlayAsync on Iphone XS
### :arrow_heading_down: What is the current behavior?
Crash with this error :

BlockLiteral.SetupBlock (System.Delegate trampoline, System.Delegate userDelegate, System.Boolean safe) /Library/Frameworks/Xamarin.iOS.framework/Versions/12.8.0.2/src/Xamarin.iOS/ObjCRuntime/Blocks.cs:94
BlockLiteral.SetupBlockUnsafe (System.Delegate trampoline, System.Delegate userDelegate) /Library/Frameworks/Xamarin.iOS.framework/Versions/12.8.0.2/src/Xamarin.iOS/ObjCRuntime/Blocks.cs:162
LOTAnimationView.PlayWithCompletion (Airbnb.Lottie.LOTAnimationCompletionBlock completion) /Users/martijn/Documents/OpenSource/LottieXamarin/Lottie.iOS/obj/Release/xamarin.ios10/ios/AirbnbLottie/LOTAnimationView.g.cs:583

### :new: What is the new behavior (if this is a feature change)?

This is not a new feature. Just a fix. Nothing change.
### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Await the end of the animation with PlayAsync or PlayWithCompletion on Iphone XS iOS 12.2

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
