### PR TITLE
Dispose resources properly to avoid creating memory leaks

### DIFF
--- a/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
@@ -146,14 +146,19 @@ namespace Lottie.Forms.iOS.Renderers
 
         private void CleanupResources()
         {
-            _animationView?.RemoveGestureRecognizer(_gestureRecognizer);
-            _animationView?.RemoveFromSuperview();
+            if (_gestureRecognizer != null)
+            {
+                _animationView?.RemoveGestureRecognizer(_gestureRecognizer);
+                _gestureRecognizer.Dispose();
+                _gestureRecognizer = null;
+            }
 
-            _gestureRecognizer.Dispose();
-            _gestureRecognizer = null;
-
-            _animationView?.Dispose();
-            _animationView = null;
+            if (_animationView != null)
+            {
+                _animationView.RemoveFromSuperview();
+                _animationView?.Dispose();
+                _animationView = null;
+            }
         }
     }
 }

--- a/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
@@ -39,6 +39,8 @@ namespace Lottie.Forms.iOS.Renderers
                 e.OldElement.OnPause -= OnPause;
                 e.OldElement.OnPlayProgressSegment -= OnPlayProgressSegment;
                 e.OldElement.OnPlayFrameSegment -= OnPlayFrameSegment;
+
+                CleanupResources();
             }
 
             if (e.NewElement == null) return;
@@ -48,7 +50,7 @@ namespace Lottie.Forms.iOS.Renderers
             e.NewElement.OnPlayProgressSegment += OnPlayProgressSegment;
             e.NewElement.OnPlayFrameSegment += OnPlayFrameSegment;
 
-            if (!string.IsNullOrEmpty(e.NewElement.Animation))
+            if (!string.IsNullOrWhiteSpace(e.NewElement.Animation))
             {
                 InitAnimationViewForElement(e.NewElement);
             }
@@ -85,10 +87,9 @@ namespace Lottie.Forms.iOS.Renderers
             if (Element == null)
                 return;
 
-            if (e.PropertyName == AnimationView.AnimationProperty.PropertyName && !string.IsNullOrEmpty(Element.Animation))
+            if (e.PropertyName == AnimationView.AnimationProperty.PropertyName && !string.IsNullOrWhiteSpace(Element.Animation))
             {
-                _animationView?.RemoveFromSuperview();
-                _animationView?.RemoveGestureRecognizer(_gestureRecognizer);
+                CleanupResources();
                 InitAnimationViewForElement(Element);
             }
 
@@ -131,19 +132,28 @@ namespace Lottie.Forms.iOS.Renderers
                 _animationView.PlayWithCompletion(PlaybackFinishedIfActually);
             }
 
-            if (_animationView != null)
-            {
-                SetNativeControl(_animationView);
-                SetNeedsLayout();
-            }
+            SetNativeControl(_animationView);
+            SetNeedsLayout();
         }
 
-        void PlaybackFinishedIfActually(bool animationFinished)
+        private void PlaybackFinishedIfActually(bool animationFinished)
         {
             if (animationFinished)
             {
                 Element?.PlaybackFinished();
             }
+        }
+
+        private void CleanupResources()
+        {
+            _animationView?.RemoveGestureRecognizer(_gestureRecognizer);
+            _animationView?.RemoveFromSuperview();
+
+            _gestureRecognizer.Dispose();
+            _gestureRecognizer = null;
+
+            _animationView?.Dispose();
+            _animationView = null;
         }
     }
 }

--- a/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Ios/AnimationViewRenderer.cs
@@ -156,7 +156,7 @@ namespace Lottie.Forms.iOS.Renderers
             if (_animationView != null)
             {
                 _animationView.RemoveFromSuperview();
-                _animationView?.Dispose();
+                _animationView.Dispose();
                 _animationView = null;
             }
         }


### PR DESCRIPTION
The current renderer implementation does not properly dispose resources, which then creates memory leaks. As described in #215, when a Xamarin Forms ListView is refreshed on iOS, new animations are created while old ones still show. This PR fixes #215.