### PR TITLE
Fix to ensure IsPlaying = true will work for UWP

### DIFF
--- a/Lottie.Forms/AnimationView.cs
+++ b/Lottie.Forms/AnimationView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Input;
 using Lottie.Forms.EventArguments;
@@ -6,7 +7,7 @@ using Xamarin.Forms;
 
 namespace Lottie.Forms
 {
-    public class AnimationView : View
+    public class AnimationView : View, IElementConfiguration<AnimationView>
     {
         public static readonly BindableProperty ProgressProperty = BindableProperty.Create(nameof(Progress),
             typeof(float), typeof(AnimationView), default(float));
@@ -44,6 +45,13 @@ namespace Lottie.Forms
 
         public static readonly BindableProperty HardwareAccelerationProperty = BindableProperty.Create(nameof(HardwareAcceleration),
             typeof(bool), typeof(AnimationView), default(bool));
+
+        readonly Lazy<Dictionary<Type, object>> _platformSpecifics;
+
+        public AnimationView()
+        {
+            _platformSpecifics = new Lazy<Dictionary<Type, object>>();
+        }
 
         public float Progress
         {
@@ -192,6 +200,16 @@ namespace Lottie.Forms
             {
                 command.Execute(null);
             }
+        }
+
+        public IPlatformElementConfiguration<T, AnimationView> On<T>() where T : IConfigPlatform
+        {
+            if (_platformSpecifics.Value.ContainsKey(typeof(T)))
+                return (IPlatformElementConfiguration<T, AnimationView>)_platformSpecifics.Value[typeof(T)];
+
+            var emptyConfig = Configuration<T, AnimationView>.Create(this);
+            _platformSpecifics.Value.Add(typeof(T), emptyConfig);
+            return emptyConfig;
         }
     }
 }

--- a/Lottie.Forms/PlatformSpecifics/Uap/AnimationViewExtensions.cs
+++ b/Lottie.Forms/PlatformSpecifics/Uap/AnimationViewExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Xamarin.Forms;
+using WindowsSpecific = Xamarin.Forms.PlatformConfiguration.Windows;
+using FormsElement = Lottie.Forms.AnimationView;
+
+namespace Lottie.Forms.PlatformConfiguration.UWPSpecific
+{
+    public static class AnimationViewExtensions
+    {
+        public static readonly BindableProperty DelayBeforeLoadMillisecondsProperty
+            = BindableProperty.Create(nameof(DelayBeforeLoadMilliseconds), typeof(int), typeof(AnimationViewExtensions), 1000);
+
+        public static int GetDelayBeforeLoadMilliseconds(BindableObject element)
+            => (int)element?.GetValue(DelayBeforeLoadMillisecondsProperty);
+
+        public static void SetDelayBeforeLoadMilliseconds(BindableObject element, int value)
+            => element?.SetValue(DelayBeforeLoadMillisecondsProperty, value);
+
+        public static int DelayBeforeLoadMilliseconds(this IPlatformElementConfiguration<WindowsSpecific, FormsElement> config)
+            => GetDelayBeforeLoadMilliseconds(config?.Element);
+
+        public static IPlatformElementConfiguration<WindowsSpecific, FormsElement> SetDelayBeforeLoadMilliseconds(this IPlatformElementConfiguration<WindowsSpecific, FormsElement> config, int value)
+        {
+            SetDelayBeforeLoadMilliseconds(config?.Element, value);
+            return config;
+        }
+    }
+}


### PR DESCRIPTION
This adds support of the `On` class so that a UWP specific property can be set `DelayBeforeLoadMilliseconds` to allow the underlying `AnimatedVisualPlayer` object to complete loading the object before initiating the `PlayAsync` call which 

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When `IsPlaying` is hard coded to true the animation would not play

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
To test this you just need to adjust the `MainPage.xaml` and `MainPage.xaml.cs` files within the `Example.Forms` project.

_`MainPage.xaml`_
You just need to update the `IsPlaying` property to true. Here is what the xaml code for the `AnimationView` should look like:
```
<forms:AnimationView 
    x:Name="animationView" 
    Grid.Row="1"
    Animation="LottieLogo1.json" 
    Loop="false" 
    IsPlaying="true"
    OnFinish="Handle_OnFinish"
    PlaybackStartedCommand="{Binding PlayingCommand}"
    PlaybackFinishedCommand="{Binding FinishedCommand}" 
    ClickedCommand="{Binding ClickedCommand}"
    VerticalOptions="FillAndExpand" 
    HorizontalOptions="FillAndExpand" />
```

_`MainPage.xaml.cs`_
Within the constructor just add this line:
```
animationView.On<Xamarin.Forms.PlatformConfiguration.Windows>().SetDelayBeforeLoadMilliseconds(1000);
```
You can set the delay to be any value. Based on testing 1 second gave enough time to allow the native view to render and allow the animation to work correctly.

### :memo: Links to relevant issues/docs
Here is the issue within LottieXamarin: [GitHub 270](https://github.com/Baseflow/LottieXamarin/issues/270)

Here is the issue for the `AnimatedVisualPlayer`: [GitHub1484](https://github.com/microsoft/microsoft-ui-xaml/issues/1484)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
