### PR TITLE
Fix android native example

### DIFF
--- a/Samples/Native/Example.Droid/Resources/layout/fragment_animation.xml
+++ b/Samples/Native/Example.Droid/Resources/layout/fragment_animation.xml
@@ -7,15 +7,15 @@
     android:clipChildren="false"
     android:orientation="vertical"
     android:background="@android:color/white">
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
     <FrameLayout
         android:id="@+id/animation_container"
         android:layout_width="match_parent"
@@ -163,7 +163,7 @@
             android:layout_marginRight="16dp"
             android:gravity="right"
             android:text="Progress" />
-        <android.support.v7.widget.AppCompatSeekBar
+        <androidx.appcompat.widget.AppCompatSeekBar
             android:id="@+id/seek_bar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -186,7 +186,7 @@
             android:layout_marginRight="16dp"
             android:gravity="right"
             android:text="Scale" />
-        <android.support.v7.widget.AppCompatSeekBar
+        <androidx.appcompat.widget.AppCompatSeekBar
             android:id="@+id/scale_seek_bar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"

--- a/Samples/Native/Example.Droid/Resources/layout/fragment_choose_asset.xml
+++ b/Samples/Native/Example.Droid/Resources/layout/fragment_choose_asset.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/Samples/Native/Example.Droid/Resources/layout/fragment_list.xml
+++ b/Samples/Native/Example.Droid/Resources/layout/fragment_list.xml
@@ -20,7 +20,7 @@
             app:lottie_loop="true" />
     </FrameLayout>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Move from `android.support.v7` to `androidx.` and from `android.support.design.widget.AppBarLayout` to `com.google.android.material.appbar.AppBarLayout`.

### :arrow_heading_down: What is the current behavior?
Android native example failes with runtime exceptions like:
![image](https://user-images.githubusercontent.com/4009570/95492576-950a6780-099b-11eb-9497-afec90b09889.png)

### :new: What is the new behavior (if this is a feature change)?
Android native example runs without runtime exceptions.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run the native android example.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
