### PR TITLE
Fixing Android repeat mode - fixes issue #288

### DIFF
--- a/Lottie.Forms/Platforms/Android/AnimationViewExtensions.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Android.Animation;
 using Com.Airbnb.Lottie;
 
 namespace Lottie.Forms.Platforms.Android
@@ -67,6 +68,30 @@ namespace Lottie.Forms.Platforms.Android
                     lottieAnimationView.ClearAnimation();
                     break;
                 default:
+                    break;
+            }
+        }
+
+        public static void ConfigureRepeat(this LottieAnimationView lottieAnimationView, RepeatMode repeatMode, int repeatCount)
+        {
+            if (lottieAnimationView == null)
+                throw new ArgumentNullException(nameof(lottieAnimationView));
+
+            lottieAnimationView.RepeatCount = repeatCount;
+
+            switch (repeatMode)
+            {
+                case RepeatMode.Infinite:
+                    {
+                        lottieAnimationView.RepeatCount = int.MaxValue;
+                        lottieAnimationView.RepeatMode = (int)ValueAnimatorRepeatMode.Restart;
+                        break;
+                    }
+                case RepeatMode.Restart:
+                    lottieAnimationView.RepeatMode = (int)ValueAnimatorRepeatMode.Restart;
+                    break;
+                case RepeatMode.Reverse:
+                    lottieAnimationView.RepeatMode = (int)ValueAnimatorRepeatMode.Reverse;
                     break;
             }
         }

--- a/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
@@ -114,11 +114,9 @@ namespace Lottie.Forms.Platforms.Android
                         _animationView.SetMaxProgress(e.NewElement.MaxProgress);
 
                     _animationView.Speed = e.NewElement.Speed;
-                    _animationView.RepeatMode = (int)e.NewElement.RepeatMode;
-                    if (e.NewElement.RepeatMode == RepeatMode.Infinite)
-                        _animationView.RepeatCount = int.MaxValue;
-                    else
-                        _animationView.RepeatCount = e.NewElement.RepeatCount;
+
+                    _animationView.ConfigureRepeat(e.NewElement.RepeatMode, e.NewElement.RepeatCount);
+
                     if (!string.IsNullOrEmpty(e.NewElement.ImageAssetsFolder))
                         _animationView.ImageAssetsFolder = e.NewElement.ImageAssetsFolder;
                     _animationView.Scale = e.NewElement.Scale;
@@ -176,17 +174,8 @@ namespace Lottie.Forms.Platforms.Android
             if (e.PropertyName == AnimationView.SpeedProperty.PropertyName)
                 _animationView.Speed = Element.Speed;
 
-            if (e.PropertyName == AnimationView.RepeatModeProperty.PropertyName)
-            {
-                _animationView.RepeatMode = (int)Element.RepeatMode;
-                if (Element.RepeatMode == RepeatMode.Infinite)
-                    _animationView.RepeatCount = int.MaxValue;
-                else
-                    _animationView.RepeatCount = Element.RepeatCount;
-            }
-
-            if (e.PropertyName == AnimationView.RepeatCountProperty.PropertyName)
-                _animationView.RepeatCount = Element.RepeatCount;
+            if (e.PropertyName == AnimationView.RepeatModeProperty.PropertyName || e.PropertyName == AnimationView.RepeatCountProperty.PropertyName)
+                _animationView.ConfigureRepeat(Element.RepeatMode, Element.RepeatCount);
 
             if (e.PropertyName == AnimationView.ImageAssetsFolderProperty.PropertyName && !string.IsNullOrEmpty(Element.ImageAssetsFolder))
                 _animationView.ImageAssetsFolder = Element.ImageAssetsFolder;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix - it fixes the mapping of the Lottie Forms RepeatMode to the values used by the native Android Library found [here](https://github.com/airbnb/lottie-android/blob/d0f006fd28044792216e609035322c86d2d8cb7d/lottie/src/main/java/com/airbnb/lottie/LottieDrawable.java#L112)

### :arrow_heading_down: What is the current behavior?
RepeatMode.Infinite does not work and instead maps to ValueAnimatorRepeatMode.Reverse

### :new: What is the new behavior (if this is a feature change)?
This PR introduces a `ConfigureRepeat` extension method which configures the repeat settings based on RepeatMode and RepeatCount

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Test that Android RepeatMode and RepeatCount properties work as intended

### :memo: Links to relevant issues/docs
Fixes this [issue](https://github.com/Baseflow/LottieXamarin/issues/288) 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
