### PR TITLE
Fix #308

### DIFF
--- a/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
@@ -79,7 +79,11 @@ namespace Lottie.Forms.Platforms.Android
                     e.NewElement.PlayCommand = new Command(() => _animationView.PlayAnimation());
                     e.NewElement.PauseCommand = new Command(() => _animationView.PauseAnimation());
                     e.NewElement.ResumeCommand = new Command(() => _animationView.ResumeAnimation());
-                    e.NewElement.StopCommand = new Command(() => _animationView.CancelAnimation());
+                    e.NewElement.StopCommand = new Command(() =>
+                    {
+                        _animationView.CancelAnimation();
+                        _animationView.Progress = 0.0f;
+                    });
                     e.NewElement.ClickCommand = new Command(() => _animationView.PerformClick());
 
                     e.NewElement.PlayMinAndMaxFrameCommand = new Command((object paramter) =>

--- a/Samples/Forms/Example.Forms/Example.Forms.csproj
+++ b/Samples/Forms/Example.Forms/Example.Forms.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,10 +8,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="LottieLogo1.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,7 +19,27 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Pages\" />
-    <Folder Include="ViewModels\" />
+    <Compile Update="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\AssetPage.xaml.cs">
+      <DependentUpon>AssetPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\ControlsPage.xaml.cs">
+      <DependentUpon>AsseControlsPagetPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\EmbeddedPage.xaml.cs">
+      <DependentUpon>EmbeddedPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\MainPage.xaml.cs">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\StreamPage.xaml.cs">
+      <DependentUpon>StreamPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Pages\UrlPage.xaml.cs">
+      <DependentUpon>UrlPage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
+
 </Project>

--- a/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml
+++ b/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml
@@ -1,89 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ContentPage 
-    xmlns="http://xamarin.com/schemas/2014/forms" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-    xmlns:forms="clr-namespace:Lottie.Forms;assembly=Lottie.Forms" 
-    xmlns:local="clr-namespace:Example.Forms" 
-    x:Class="Example.Forms.ControlsPage">
-    <ContentPage.BindingContext>
-        <local:ControlsViewModel />
-    </ContentPage.BindingContext>
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
+<ContentPage
+  xmlns="http://xamarin.com/schemas/2014/forms"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:forms="clr-namespace:Lottie.Forms;assembly=Lottie.Forms"
+  xmlns:local="clr-namespace:Example.Forms"
+  x:Class="Example.Forms.ControlsPage">
 
-        <StackLayout
-            Grid.Row="0"
-            Orientation="Horizontal"
-            HorizontalOptions="FillAndExpand"
-            Margin="5, 0">
-            
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="Play" 
-                Command="{Binding PlayCommand}"
-                CommandParameter="{x:Reference animationView}" />
-            
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="Pause" 
-                Command="{Binding PauseCommand}"
-                CommandParameter="{x:Reference animationView}" />
+  <ContentPage.BindingContext>
+    <local:ControlsViewModel />
+  </ContentPage.BindingContext>
 
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="Cancel" 
-                Command="{Binding CancelCommand}"
-                CommandParameter="{x:Reference animationView}" />
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="*" />
+      <RowDefinition
+        Height="Auto" />
+    </Grid.RowDefinitions>
 
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="Resume" 
-                Command="{Binding ResumeCommand}"
-                CommandParameter="{x:Reference animationView}" />
-        </StackLayout>
+    <StackLayout
+      Grid.Row="0"
+      Orientation="Horizontal"
+      HorizontalOptions="FillAndExpand"
+      Margin="5, 0">
 
-        <StackLayout
-            Grid.Row="1"
-            Orientation="Horizontal"
-            HorizontalOptions="FillAndExpand"
-            Margin="5, 0">
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="MinAndMaxFrame"
-                Command="{Binding MinAndMaxFrameCommand}"
-                CommandParameter="{x:Reference animationView}" />
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="Play"
+        Command="{Binding PlayCommand}"
+        CommandParameter="{x:Reference animationView}" />
 
-            <Button 
-                HorizontalOptions="FillAndExpand"
-                Text="MinAndMaxProgress"
-                Command="{Binding MinAndMaxProgressCommand}"
-                CommandParameter="{x:Reference animationView}" />
-        </StackLayout>
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="Pause"
+        Command="{Binding PauseCommand}"
+        CommandParameter="{x:Reference animationView}" />
 
-        <forms:AnimationView 
-            x:Name="animationView" 
-            Grid.Row="2" 
-            BackgroundColor="Red"
-            Animation="LottieLogo1.json"
-            RepeatMode="Restart"
-            RepeatCount="3"
-            MinFrame="20"
-            MaxFrame="80"
-            OnAnimationUpdate="animationView_OnAnimationUpdate"
-            IsAnimating="{Binding IsAnimating}"
-            Command="{Binding ClickCommand}"
-            VerticalOptions="FillAndExpand" 
-            HorizontalOptions="FillAndExpand" />
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="Cancel"
+        Command="{Binding CancelCommand}"
+        CommandParameter="{x:Reference animationView}" />
 
-        <Slider 
-            Grid.Row="3"
-            Margin="5, 0"
-            x:Name="progressSlider"
-            ValueChanged="Slider_OnValueChanged" />
-    </Grid>
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="Resume"
+        Command="{Binding ResumeCommand}"
+        CommandParameter="{x:Reference animationView}" />
+    </StackLayout>
+
+    <StackLayout
+      Grid.Row="1"
+      Orientation="Horizontal"
+      HorizontalOptions="FillAndExpand"
+      Margin="5, 0">
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="MinAndMaxFrame"
+        Command="{Binding MinAndMaxFrameCommand}"
+        CommandParameter="{x:Reference animationView}" />
+
+      <Button
+        HorizontalOptions="FillAndExpand"
+        Text="MinAndMaxProgress"
+        Command="{Binding MinAndMaxProgressCommand}"
+        CommandParameter="{x:Reference animationView}" />
+    </StackLayout>
+
+    <forms:AnimationView
+      x:Name="animationView"
+      Grid.Row="2"
+      BackgroundColor="Red"
+      Animation="LottieLogo1.json"
+      RepeatMode="Restart"
+      RepeatCount="3"
+      MinFrame="20"
+      MaxFrame="80"
+      OnAnimationUpdate="AnimationView_OnAnimationUpdate"
+      IsAnimating="{Binding IsAnimating}"
+      Command="{Binding ClickCommand}"
+      VerticalOptions="FillAndExpand"
+      HorizontalOptions="FillAndExpand" />
+
+    <Slider
+      Grid.Row="3"
+      Margin="5, 0"
+      x:Name="progressSlider"
+      ValueChanged="Slider_OnValueChanged" />
+  </Grid>
 </ContentPage>

--- a/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml.cs
+++ b/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System;
+using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Example.Forms
@@ -12,19 +13,14 @@ namespace Example.Forms
             On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(true);
         }
 
-        private void Slider_OnValueChanged(object sender, ValueChangedEventArgs e)
-        {
-            //animationView.Progress = (float)e.NewValue;
-        }
-
-        private void Handle_OnFinish(object sender, System.EventArgs e)
-        {
-            DisplayAlert(string.Empty, $"{nameof(animationView.OnFinishedAnimation)} invoked!", "OK");
-        }
-
-        private void animationView_OnAnimationUpdate(object sender, float e)
+        private void AnimationView_OnAnimationUpdate(object sender, float e)
         {
             progressSlider.Value = e;
+        }
+
+        private void Slider_OnValueChanged(object sender, ValueChangedEventArgs e)
+        {
+            animationView.Progress = (float)e.NewValue;
         }
     }
 }

--- a/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml.cs
+++ b/Samples/Forms/Example.Forms/Pages/ControlsPage.xaml.cs
@@ -13,6 +13,32 @@ namespace Example.Forms
             On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(true);
         }
 
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            if (BindingContext is ControlsViewModel controlsViewModel)
+            {
+                controlsViewModel.AnimationClicked -= ControlsViewModel_AnimationClicked;
+                controlsViewModel.AnimationClicked += ControlsViewModel_AnimationClicked;
+            }
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+
+            if (BindingContext is ControlsViewModel controlsViewModel)
+            {
+                controlsViewModel.AnimationClicked -= ControlsViewModel_AnimationClicked;
+            }
+        }
+
+        private void ControlsViewModel_AnimationClicked(object sender, EventArgs e)
+        {
+            DisplayAlert("Clicked", "You have clicked on the animation.", "OK");
+        }
+
         private void AnimationView_OnAnimationUpdate(object sender, float e)
         {
             progressSlider.Value = e;

--- a/Samples/Forms/Example.Forms/ViewModels/ControlsViewModel.cs
+++ b/Samples/Forms/Example.Forms/ViewModels/ControlsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Windows.Input;
 using Lottie.Forms;
 using Xamarin.Forms;
 
@@ -6,6 +7,8 @@ namespace Example.Forms
 {
     public class ControlsViewModel : BaseViewModel
     {
+        public event EventHandler AnimationClicked;
+
         public ControlsViewModel()
         {
             PlayCommand = new Command<AnimationView>((animationView) =>
@@ -26,7 +29,8 @@ namespace Example.Forms
             });
             ClickCommand = new Command<AnimationView>((animationView) =>
             {
-                //TODO: Show message it is clicked
+                var animationClickedHandler = AnimationClicked;
+                animationClickedHandler?.Invoke(this, EventArgs.Empty);
             });
             MinAndMaxFrameCommand = new Command<AnimationView>((animationView) =>
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix #308 
Example.Forms project updates

### :arrow_heading_down: What is the current behavior?
The animation does not reset on Android, when the Stop method is called. On iOS there is a reset.

### :new: What is the new behavior (if this is a feature change)?
The animation does now also reset on Android. Same behavior as on iOS.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
