### PR TITLE
Implement EnableMergePathsForKitKatAndAbove property

### DIFF
--- a/Lottie.Forms/AnimationView.cs
+++ b/Lottie.Forms/AnimationView.cs
@@ -72,6 +72,9 @@ namespace Lottie.Forms
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command),
             typeof(ICommand), typeof(AnimationView));
 
+        public static readonly BindableProperty EnableMergePathsForKitKatAndAboveProperty = BindableProperty.Create(nameof(EnableMergePathsForKitKatAndAbove),
+            typeof(bool), typeof(AnimationView), false);
+
         /// <summary>
         /// Returns the duration of an animation (Frames / FrameRate * 1000)
         /// </summary>
@@ -254,6 +257,15 @@ namespace Lottie.Forms
         {
             get { return (ICommand)GetValue(CommandProperty); }
             set { SetValue(CommandProperty, value); }
+        }
+
+        /// <summary>
+        /// When true the Lottie animation will enable merge paths for devices with KitKat and above
+        /// </summary>
+        public bool EnableMergePathsForKitKatAndAbove
+        {
+            get { return (bool)GetValue(EnableMergePathsForKitKatAndAboveProperty); }
+            set { SetValue(EnableMergePathsForKitKatAndAboveProperty, value); }
         }
 
         /// <summary>

--- a/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
+++ b/Lottie.Forms/Platforms/Android/AnimationViewRenderer.cs
@@ -137,6 +137,8 @@ namespace Lottie.Forms.Platforms.Android
 
                     e.NewElement.Duration = _animationView.Duration;
                     e.NewElement.IsAnimating = _animationView.IsAnimating;
+
+                    _animationView.EnableMergePathsForKitKatAndAbove(e.NewElement.EnableMergePathsForKitKatAndAbove);
                 }
             }
         }

--- a/Lottie.Forms/readme.txt
+++ b/Lottie.Forms/readme.txt
@@ -32,6 +32,7 @@ All options:
     CacheComposition="True"
     Clicked="animationView_Clicked"
     Command="{Binding ClickCommand}"
+    EnableMergePathsForKitKatAndAbove="True"
     FallbackResource="{Binding Image}"
     ImageAssetsFolder="Assets/lottie"
     IsAnimating="{Binding IsAnimating}"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature: adds EnableMergePathsForKitKatAndAbove property to the Xamarin.Forms AnimationView.
Where supported; enabling the property you can render the animation using merge paths.

### :arrow_heading_down: What is the current behavior?
Merge paths are disabled by default and there is no way to enable it from shared project.

### :new: What is the new behavior (if this is a feature change)?
Ability to enable/disable merge paths of AnimationView control. 

### :boom: Does this PR introduce a breaking change?
No, previously EnableMergePathsForKitKatAndAbove was not exposed so it defaults to false, this property also defaults to false.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Had this exact issue a couple days before
https://github.com/Baseflow/LottieXamarin/issues/317

### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines 
- [ X ] Relevant documentation was updated
- [ X ] Rebased onto current develop
