### PR TITLE
feat: Add .NET 6 Mobile support

### DIFF
--- a/Lottie.Android/Lottie.Android.csproj
+++ b/Lottie.Android/Lottie.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>monoandroid10.0</TargetFrameworks>
+    <TargetFrameworks>monoandroid10.0;net6.0-android</TargetFrameworks>
     <AssemblyName>Lottie.Android</AssemblyName>
     <RootNamespace>Lottie.Android</RootNamespace>
     <Description>Render After Effects animations natively on Android, iOS, MacOS, TVOs and UWP</Description>

--- a/Lottie.iOS/Lottie.iOS.csproj
+++ b/Lottie.iOS/Lottie.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>    
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">xamarin.ios10</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">xamarin.ios10;xamarin.mac20;xamarin.tvos10</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">xamarin.ios10;net6.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">xamarin.ios10;xamarin.mac20;xamarin.tvos10;net6.0-ios;net6.0-macos;net6.0-maccatalyst;net6.0-tvos</TargetFrameworks>
     <AssemblyName>Lottie.iOS</AssemblyName>
     <RootNamespace>Lottie.iOS</RootNamespace>
     <Description>Render After Effects animations natively on Android, iOS, MacOS, TVOs and UWP</Description>

--- a/Lottie.iOS/Lottie.iOS.csproj
+++ b/Lottie.iOS/Lottie.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>    
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">xamarin.ios10;net6.0-ios</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">xamarin.ios10;xamarin.mac20;xamarin.tvos10;net6.0-ios;net6.0-macos;net6.0-maccatalyst;net6.0-tvos</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">xamarin.ios10;xamarin.mac20;xamarin.tvos10;net6.0-ios;net6.0-macos;net6.0-tvos</TargetFrameworks>
     <AssemblyName>Lottie.iOS</AssemblyName>
     <RootNamespace>Lottie.iOS</RootNamespace>
     <Description>Render After Effects animations natively on Android, iOS, MacOS, TVOs and UWP</Description>
@@ -23,7 +23,7 @@
     <Compile Include="LOTAnimationView.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.ios')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.ios')) or $(TargetFramework.StartsWith('net6.0-ios')) ">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Ios.cs" />
     <ObjcBindingNativeLibrary Include="libLottie-ios.a" />
     <Compile Include="libLottie-ios.linkwith.cs">
@@ -31,7 +31,7 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.mac')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.mac')) or $(TargetFramework.StartsWith('net6.0-macos')) ">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Mac.cs" />
     <ObjcBindingNativeLibrary Include="libLottie-macos.a" />
     <Compile Include="libLottie-macos.linkwith.cs">
@@ -39,12 +39,12 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.tvos')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.tvos')) or $(TargetFramework.StartsWith('net6.0-tvos')) ">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Ios.cs" />
     <ObjcBindingNativeLibrary Include="libLottie-tvos.a" />
     <Compile Include="libLottie-tvos.linkwith.cs">
       <DependentUpon>libLottie-tvos.a</DependentUpon>
     </Compile>
   </ItemGroup>
-  
+
 </Project>

--- a/Lottie.sln
+++ b/Lottie.sln
@@ -1,8 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29209.62
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32314.265
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lottie.Forms", "Lottie.Forms\Lottie.Forms.csproj", "{F03D2DD6-BBDA-45B9-982E-4DCA43FCB8E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lottie.Forms", "Lottie.Forms\Lottie.Forms.csproj", "{F03D2DD6-BBDA-45B9-982E-4DCA43FCB8E1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lottie.iOS", "Lottie.iOS\Lottie.iOS.csproj", "{8F0CC2B2-88E2-459B-AC92-F3A74071707E}"
 EndProject
@@ -707,7 +707,6 @@ Global
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Debug|x86.Build.0 = Debug|Any CPU
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Release|ARM.ActiveCfg = Release|Any CPU
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Release|ARM.Build.0 = Release|Any CPU
 		{A7CECB0B-C674-462C-8E50-6A21BC41A62D}.Release|iPhone.ActiveCfg = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LottieXamarin
-Lottie is a mobile library for Android and iOS that parses [Adobe After Effects](http://www.adobe.com/products/aftereffects.html) animations exported as json with [Bodymovin](https://github.com/bodymovin/bodymovin) and renders them natively on mobile!
+Lottie is a mobile library for Android and iOS (Xamarin and .NET 6) that parses [Adobe After Effects](http://www.adobe.com/products/aftereffects.html) animations exported as json with [Bodymovin](https://github.com/bodymovin/bodymovin) and renders them natively on mobile!
 
 # Support
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,16 @@
       only:
         - develop
   version: 1.0.{build}
-  image: Visual Studio 2019
+  image: Visual Studio 2022
   before_build:
+  - ps: |
+      $ProgressPreference = 'SilentlyContinue'
+      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      & .\dotnet-install.ps1 -Version 6.0.300-preview.22154.4 -InstallDir "$env:ProgramFiles\dotnet\"
+  - ps: |
+      # Use uno-check to install an early .NET 6.0.300 rc1 build which does not require jumping through hoops: https://github.com/dotnet/maui/releases/tag/6.0.200-preview.14.2
+      dotnet tool update --global uno.check --version 1.1.1 --add-source https://api.nuget.org/v3/index.json
+      uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidemulator --manifest https://raw.githubusercontent.com/unoplatform/uno.check/d14571a546b55f58e51e392c04cf098168d6fe2d/manifests/uno.ui-preview.manifest.json
   - cmd: dotnet --info
   - cmd: dotnet tool install --tool-path . SignClient
   environment:

--- a/build.cake
+++ b/build.cake
@@ -376,7 +376,7 @@ MSBuildSettings GetDefaultBuildSettings()
         ToolPath = msBuildPath,
         Verbosity = verbosity,
         ArgumentCustomization = args => args.Append("/m"),
-        ToolVersion = MSBuildToolVersion.VS2019
+        ToolVersion = MSBuildToolVersion.VS2022
     };
 
     return settings;

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"
+  },
+  "sdk": {
+    "allowPrerelease": true
   }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.34.1" />
+    <package id="Cake" version="1.3.0" />
 </packages>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds .NET 6.0.300 Mobile support, iOS, macOS and watchOS. 

There are no archives for catalyst (the objective-C support at the time may not have had it), so net6.0-maccatalyst is not present.

Fixes https://github.com/Baseflow/LottieXamarin/issues/363

### :boom: Does this PR introduce a breaking change?
None

### :bug: Recommendations for testing
Create a MAUI (Preview 14 or later) or Uno Platform (4.1.9 or later) project and include the Lottie control.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
